### PR TITLE
Add const correctness to City class basic getter methods

### DIFF
--- a/city.cc
+++ b/city.cc
@@ -255,12 +255,12 @@ void City::print_GDP()
  *
  */
 
-int City::get_time()
+int City::get_time() const
 {
     return clock_->get_time();
 }
 
-Clock *City::get_clock()
+Clock *City::get_clock() const
 {
     return clock_;
 }
@@ -299,7 +299,7 @@ double City::get_capital_sum()
     return csum;
 }
 
-int City::get_no_companies()
+int City::get_no_companies() const
 {
     return company_list_->get_size();
 }
@@ -341,7 +341,7 @@ double City::get_inflation_target()
     return inflation_target_;
 }
 
-Company *City::get_company(string name)
+Company *City::get_company(const string& name)
 {
     return company_list_->get_company(name);
 }
@@ -393,12 +393,12 @@ int City::get_time_to_steal()
     return time_to_steal_;
 }
 
-string City::get_name()
+string City::get_name() const
 {
     return name_;
 }
 
-int City::get_no_consumers()
+int City::get_no_consumers() const
 {
     return consumers_->get_size();
     ;

--- a/city.h
+++ b/city.h
@@ -45,17 +45,17 @@ class City {
        * Get-funktioner
        */
 
-      int get_time();
-      Clock * get_clock();
+      int get_time() const;
+      Clock * get_clock() const;
       Market * get_market();
       Bank * get_bank();
       double get_consumer_capital_sum();
       double get_company_capacity_sum();
       double get_expected_consumer_net_flow_to_bank_sum();
-      int get_no_companies(); 
+      int get_no_companies() const; 
       double get_capital_sum(); 
       double get_loans_to_bank();
-      Company * get_company(string name);
+      Company * get_company(const string& name);
       Consumer * get_random_consumer();
       Company * get_random_company();
       Consumer * get_optimal_consumer(double mot_we, double skill_we, int production_function, double production_parameter);
@@ -69,8 +69,8 @@ class City {
       double get_inflation_target();
       int get_no_years_laundry();
       int get_time_to_steal();
-      string get_name();
-      int get_no_consumers();
+      string get_name() const;
+      int get_no_consumers() const;
       
       /*
        * Change-functions


### PR DESCRIPTION
- Modified get_time() to be const
- Modified get_clock() to be const
- Modified get_no_companies() to be const
- Modified get_no_consumers() to be const
- Modified get_name() to be const
- Modified get_company() to accept const string reference

This improves code safety by preventing modification of data through getter methods. Follows the same pattern established in World class.

Fixes #1