### PR TITLE
Add const correctness to Bank class getter methods

### DIFF
--- a/bank.cc
+++ b/bank.cc
@@ -47,11 +47,11 @@ void Bank::info() {
     
 }
 
-double Bank::get_interest() {
+double Bank::get_interest() const {
     return interest_rate_;
 }
 
-double Bank::get_interest_margin() {
+double Bank::get_interest_margin() const {
 	
 	return interest_margin_;
 }
@@ -73,31 +73,31 @@ double Bank::get_interest_rate_loans() {
 
 
 
-double Bank::get_target_interest() {
+double Bank::get_target_interest() const {
     return target_interest_;
 }
 
-int Bank::get_interest_rate_method() {
+int Bank::get_interest_rate_method() const {
     return interest_rate_method_;
 }
 
-double Bank::get_capital() {
+double Bank::get_capital() const {
     return capital_;
 }
 
-double Bank::get_deposits() {
+double Bank::get_deposits() const {
     return deposits_;
 }
 
-double Bank::get_loans() {
+double Bank::get_loans() const {
     return loans_;
 }
 
-double Bank::get_liquidity() {
+double Bank::get_liquidity() const {
     return liquidity_;
 }
 
-double Bank::get_payback_time() {
+double Bank::get_payback_time() const {
     return payback_time_;
 }
 
@@ -166,20 +166,20 @@ double Bank::get_max_customer_borrow() {
 
 
 
-double Bank::get_dividend_ratio() {
+double Bank::get_dividend_ratio() const {
     return div_ratio_;
 }
 
-double Bank::get_liquidity_reserve_ratio() {
+double Bank::get_liquidity_reserve_ratio() const {
     return liquidity_reserve_ratio_;
 }
 
-double Bank::get_capital_reserve_ratio() {
+double Bank::get_capital_reserve_ratio() const {
     return capital_reserve_ratio_;
 }
 
 
-bool Bank::get_trustworthy() {
+bool Bank::get_trustworthy() const {
     return trustworthy_;
 }
 

--- a/bank.h
+++ b/bank.h
@@ -21,24 +21,24 @@ public:
 
    void info();
 
-   double get_interest();
-   double get_interest_margin();
+   double get_interest() const;
+   double get_interest_margin() const;
    double get_interest_rate_deposits();
    double get_interest_rate_loans();
-   double get_target_interest();
-   int get_interest_rate_method();
-   double get_capital();
-   double get_deposits();
-   double get_loans();
-   double get_liquidity();
-   double get_payback_time();
+   double get_target_interest() const;
+   int get_interest_rate_method() const;
+   double get_capital() const;
+   double get_deposits() const;
+   double get_loans() const;
+   double get_liquidity() const;
+   double get_payback_time() const;
    double get_loan_cost(double);
    double get_sum_to_borrow();
    double get_max_customer_borrow();
-   double get_dividend_ratio();
-   double get_capital_reserve_ratio();
-   double get_liquidity_reserve_ratio();
-   bool get_trustworthy();
+   double get_dividend_ratio() const;
+   double get_capital_reserve_ratio() const;
+   double get_liquidity_reserve_ratio() const;
+   bool get_trustworthy() const;
 
    void set_interest(double);
    void set_target_interest(double);


### PR DESCRIPTION
## Description
Add const correctness to 13 simple accessor getter methods in the Bank class.

## Changes
- Made all simple accessor getter methods const qualified
- Updated both header file (bank.h) and implementation file (bank.cc)
- Ensures these methods don't modify object state
- Follows const-correctness best practices

## Simple accessor methods updated to const:
- get_interest()
- get_interest_margin()
- get_target_interest()
- get_interest_rate_method()
- get_capital()
- get_deposits()
- get_loans()
- get_liquidity()
- get_payback_time()
- get_dividend_ratio()
- get_capital_reserve_ratio()
- get_liquidity_reserve_ratio()
- get_trustworthy()

## Methods left non-const (complex logic):
These methods perform calculations or have complex logic, so they were intentionally left non-const:
- get_interest_rate_deposits() - calculates: interest_rate_ - interest_margin_/2
- get_interest_rate_loans() - calculates: interest_rate_ + interest_margin_/2  
- get_loan_cost(double) - complex calculation with loops
- get_sum_to_borrow() - complex logic with conditionals
- get_max_customer_borrow() - complex logic with conditionals

## Testing
- [x] Code compiles successfully with no errors
- [x] Only warnings related to existing unused variables remain
- [x] No functional changes to simulation behavior

Resolves #9